### PR TITLE
Add assertions to TaskList.java

### DIFF
--- a/src/main/java/performative/tasks/TaskList.java
+++ b/src/main/java/performative/tasks/TaskList.java
@@ -24,8 +24,10 @@ public class TaskList {
      * @param tasks ArrayList of existing tasks to initialize the TaskList with.
      */
     public TaskList(ArrayList<Task> tasks) {
+        assert tasks != null : "Task list cannot be null";
         this.tasks = tasks;
         this.taskCount = tasks.size();
+        assert this.taskCount >= 0 : "Task count must be non-negative";
     }
 
     /**
@@ -35,6 +37,8 @@ public class TaskList {
      * @return The Task object at the specified position.
      */
     public Task getTask(int taskNumber) {
+        assert taskNumber >= 1 && taskNumber <= taskCount : "Task number must be between 1 and " + taskCount;
+        assert tasks.size() == taskCount : "Internal state inconsistent: tasks.size() != taskCount";
         return this.tasks.get(taskNumber - 1);
     }
 
@@ -63,8 +67,12 @@ public class TaskList {
      * @param task The task to be added to the list.
      */
     public void addTask(Task task) {
+        assert task != null : "Cannot add null task";
+        int oldCount = this.taskCount;
         this.tasks.add(task);
         this.taskCount += 1;
+        assert this.taskCount == oldCount + 1 : "Task count should increase by exactly 1";
+        assert tasks.size() == taskCount : "Internal state inconsistent after adding task";
     }
 
     /**
@@ -75,8 +83,14 @@ public class TaskList {
      * @return The removed Task object.
      */
     public Task deleteTask(int taskNumber) {
+        assert taskNumber >= 1 && taskNumber <= taskCount : "Task number must be between 1 and " + taskCount;
+        assert taskCount > 0 : "Cannot delete from empty task list";
+        int oldCount = this.taskCount;
         Task removedTask = tasks.remove(taskNumber - 1);
         this.taskCount -= 1;
+        assert this.taskCount == oldCount - 1 : "Task count should decrease by exactly 1";
+        assert tasks.size() == taskCount : "Internal state inconsistent after deleting task";
+        assert removedTask != null : "Removed task should not be null";
         return removedTask;
     }
 }


### PR DESCRIPTION
There are some ways where incorrect inputs can cause tasks to be added and formatted incorrectly.
Using the java assert keyword in TaskList.java helps to identify bugs more easily and prevents potential corrupted tasks being added.